### PR TITLE
Replace custom language codes with array

### DIFF
--- a/data/idioms.yml
+++ b/data/idioms.yml
@@ -58,11 +58,10 @@
       original: Nagyobb a füstje, mint a lángja
       en: The smoke is bigger than the flame
     it:
-      original: Tutto fumo e niente arrosto
-      en: All smoke and no roast
-    it2:
-      original: Can che abbaia non morde
-      en: A dog that barks doesn't bite
+      - original: Tutto fumo e niente arrosto
+        en: All smoke and no roast
+      - original: Can che abbaia non morde
+        en: A dog that barks doesn't bite
 
 -
   en: All that glitters is not gold


### PR DESCRIPTION
To allow for multiple idioms for the same idea, allow an array of objects
to be specified instead of a singal object. Custom language codes might
get confusing later on.

So, rather than `it` and `it2`:

```yml
    it:
      original: Tutto fumo e niente arrosto
      en: All smoke and no roast
    it2:
      original: Can che abbaia non morde
      en: A dog that barks doesn't bite
```

Perhaps cleaner to use:

```yml
    it:
      - original: Tutto fumo e niente arrosto
        en: All smoke and no roast
      - original: Can che abbaia non morde
        en: A dog that barks doesn't bite
```

Thoughts?